### PR TITLE
[yokurang]: Added a --file flag to accept allow to read the patch from a file as a required command line argument

### DIFF
--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,16 +1,19 @@
 open Diffcessible
+open Cmdliner
 
-let main () =
-  let file = In_channel.open_bin "diff.example" in
+let main file_path =
+  let file = In_channel.open_bin file_path in
   let s = In_channel.input_all file in
   let patch = Patch.to_diffs s in
   Interactive_viewer.start patch
 
-open Cmdliner
+let file_arg =
+  let doc = "Path to the file containing the Git diff." in
+  Arg.(required & opt (some string) None & info ["f"; "file"] ~docv:"FILE" ~doc)
 
 let cmd =
   let doc = "Render Git diffs in an accessible way." in
   let info = Cmd.info "diffcessible" ~version:"VERSION" ~doc in
-  Cmd.v info Term.(const main $ const ())
+  Cmd.v info Term.(const main $ file_arg)
 
 let () = exit (Cmd.eval cmd)

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -9,7 +9,7 @@ let main file_path =
 
 let file_arg =
   let doc = "Path to the file containing the Git diff." in
-  Arg.(required & opt (some string) None & info ["f"; "file"] ~docv:"FILE" ~doc)
+  Arg.(required & pos 0 (some string) None & info [] ~docv:"FILE" ~doc)
 
 let cmd =
   let doc = "Render Git diffs in an accessible way." in

--- a/diffcessible.opam
+++ b/diffcessible.opam
@@ -14,7 +14,6 @@ depends: [
   "cmdliner"
   "seq"
   "notty" {>= "0.2"}
-  "lwt"
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Hi, I implemented a fix for this issue: https://github.com/panglesd/diffcessible/issues/3

After pulling from this branch, run 

```
dune clean && dune build
```
and execute the binary with the flag to see the results

```
dune exec -- diffcessible --file diff.example
```