### PR TITLE
Display Number of Hunks in Interactive Viewer Status Bar

### DIFF
--- a/lib/interactive_viewer.ml
+++ b/lib/interactive_viewer.ml
@@ -8,8 +8,8 @@ let operation_info z_patches : ui Lwd.t =
   let num_hunks = List.length p.Patch.hunks in
   let hunk_text =
     match num_hunks with
-    | n when n > 1 || n = 0 -> Printf.sprintf "%d hunks" n
-    | _ -> "1 hunk"
+    | 1 -> "1 hunk"
+    | _ -> Printf.sprintf "%d hunks" num_hunks
   in
   W.string
     ~attr:Notty.A.(fg lightcyan)

--- a/lib/interactive_viewer.ml
+++ b/lib/interactive_viewer.ml
@@ -6,12 +6,17 @@ let operation_info z_patches : ui Lwd.t =
   let$ z = Lwd.get z_patches in
   let p = Zipper.get_focus z in
   let num_hunks = List.length p.Patch.hunks in
+  let hunk_text = match num_hunks with
+    | 1 -> "1 hunk"
+    | n when n > 1 -> Printf.sprintf "%d hunks" n
+    | _ -> "0 hunks"
+in
   W.string
     ~attr:Notty.A.(fg lightcyan)
-    (Printf.sprintf "Operation %d of %d, Hunks: %d "
+    (Printf.sprintf "Operation %d of %d, %s "
        (Zipper.get_current_index z + 1)
        (Zipper.get_total_length z)
-       num_hunks)
+       hunk_text)
 
 let ui_of_operation operation =
   let green_bold_attr = Notty.A.(fg green ++ st bold) in

--- a/lib/interactive_viewer.ml
+++ b/lib/interactive_viewer.ml
@@ -4,11 +4,14 @@ open Lwd_infix
 
 let operation_info z_patches : ui Lwd.t =
   let$ z = Lwd.get z_patches in
+  let p = Zipper.get_focus z in
+  let num_hunks = List.length p.Patch.hunks in
   W.string
     ~attr:Notty.A.(fg lightcyan)
-    (Printf.sprintf "Operation %d of %d"
+    (Printf.sprintf "Operation %d of %d, Hunks: %d "
        (Zipper.get_current_index z + 1)
-       (Zipper.get_total_length z))
+       (Zipper.get_total_length z)
+       num_hunks)
 
 let ui_of_operation operation =
   let green_bold_attr = Notty.A.(fg green ++ st bold) in

--- a/lib/interactive_viewer.ml
+++ b/lib/interactive_viewer.ml
@@ -7,9 +7,8 @@ let operation_info z_patches : ui Lwd.t =
   let p = Zipper.get_focus z in
   let num_hunks = List.length p.Patch.hunks in
   let hunk_text = match num_hunks with
-    | 1 -> "1 hunk"
-    | n when n > 1 -> Printf.sprintf "%d hunks" n
-    | _ -> "0 hunks"
+    | n when n > 1 || n = 0 -> Printf.sprintf "%d hunks" n
+    | _ -> "1 hunk"
 in
   W.string
     ~attr:Notty.A.(fg lightcyan)

--- a/lib/interactive_viewer.ml
+++ b/lib/interactive_viewer.ml
@@ -6,13 +6,14 @@ let operation_info z_patches : ui Lwd.t =
   let$ z = Lwd.get z_patches in
   let p = Zipper.get_focus z in
   let num_hunks = List.length p.Patch.hunks in
-  let hunk_text = match num_hunks with
+  let hunk_text =
+    match num_hunks with
     | n when n > 1 || n = 0 -> Printf.sprintf "%d hunks" n
     | _ -> "1 hunk"
-in
+  in
   W.string
     ~attr:Notty.A.(fg lightcyan)
-    (Printf.sprintf "Operation %d of %d, %s "
+    (Printf.sprintf "Operation %d of %d, %s"
        (Zipper.get_current_index z + 1)
        (Zipper.get_total_length z)
        hunk_text)

--- a/lib/zipper.mli
+++ b/lib/zipper.mli
@@ -27,4 +27,3 @@ val get_total_length : 'a t -> int
 
 val get_current_index : 'a t -> int
 (** [get_current_index z] returns the current index (0-based) of the focus in the list. *)
-


### PR DESCRIPTION
This PR introduces an enhancement to the interactive viewer's status bar, specifically to display the number of hunks for the current operation. This update aims to improve the user experience by providing a clearer overview of the changes being reviewed.

**Changes:**
- Modified the **_operation_ info_** function in **_interactive_viewer.ml_** to include the number of hunks in the status bar display.

**Purpose:**
The primary goal of this update is to make the interactive viewer more informative and user-friendly. 
By displaying the number of hunks, users can quickly understand the scope of changes for each operation, facilitating a more efficient review process.

@panglesd 