### PR TITLE
CI testing using Github Actions

### DIFF
--- a/.github/workflows/ci-pull-request.yml
+++ b/.github/workflows/ci-pull-request.yml
@@ -1,0 +1,41 @@
+name: Install, test and format
+
+on:
+  pull_request:
+    branches:
+      - "main"
+
+permissions: read-all
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+        ocaml-compiler:
+          - "5.1"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set-up OCaml version:${{ matrix.ocaml-compiler }} in os:${{ matrix.os }}
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+
+      - name: Install Dependencies
+        run: |
+          opam install --deps-only -t -y .
+          opam install ocamlformat.0.26.1
+
+      - name: Test
+        run: opam exec -- dune runtest
+
+      - name: Format
+        run: opam exec -- dune build @fmt


### PR DESCRIPTION
Added a github workflow file that will trigger GitHub actions to execute the ci when raising a PR
fix for issue: https://github.com/panglesd/diffcessible/issues/37

Screenshot from the github actions for reference. 
<img width="1728" alt="Screenshot 2024-03-12 at 10 20 14 AM" src="https://github.com/panglesd/diffcessible/assets/122064139/b4b8fae6-94e9-4f1a-92a2-de904f13d188">

@Julow @panglesd have a look